### PR TITLE
Ensure computing MI doesn't allocate

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,3 @@
+margin = 120
+remove_extra_newlines = true
+format_docstrings = true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,7 @@ jobs:
         version:
           - '1.5'
           - '1.6'
+          - '1.7'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/codeformat-pr.yml
+++ b/.github/workflows/codeformat-pr.yml
@@ -3,7 +3,7 @@ name: Code Formatting
 on:
   pull_request:
     branches:
-      - master
+      - main
     types: [opened, edited, reopened, synchronize]
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 /docs/build/
 Manifest.toml
+LocalPreferences.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MutualInformationImageRegistration"
 uuid = "f55eb597-e6a1-4806-8966-600fcb3de930"
 authors = ["Octogonapus <firey45@gmail.com> and contributors"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 FastHistograms = "06971c4e-2824-4b19-bcf3-55442efb9bc7"

--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,14 @@ version = "0.1.3"
 
 [deps]
 FastHistograms = "06971c4e-2824-4b19-bcf3-55442efb9bc7"
+LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [compat]
 FastHistograms = "0.2"
 OffsetArrays = "1.4"
+LoopVectorization = "0.12"
 julia = "1.5"
+
+[extras]
+CPUSummary = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"

--- a/dev/Project.toml
+++ b/dev/Project.toml
@@ -8,3 +8,6 @@ ImageShow = "4e3cecfd-b093-5904-9786-8bbb286a6a31"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 MutualInformationImageRegistration = "f55eb597-e6a1-4806-8966-600fcb3de930"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
+
+[extras]
+CPUSummary = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"

--- a/dev/benchmark.jl
+++ b/dev/benchmark.jl
@@ -41,18 +41,9 @@ function bench_register()
 
     expected_x = 5
     expected_y = -5
-    moving =
-        [300, 200, 330, 220] .+ padding .+ [expected_x, expected_y, expected_x, expected_y]
+    moving = [300, 200, 330, 220] .+ padding .+ [expected_x, expected_y, expected_x, expected_y]
 
-    bm = @benchmark register!(
-        $mi,
-        $full_image,
-        $fixed,
-        $moving,
-        $MAX_SHIFT,
-        $MAX_SHIFT,
-        $buffer,
-    )
+    bm = @benchmark register!($mi, $full_image, $fixed, $moving, $MAX_SHIFT, $MAX_SHIFT, $buffer)
     display(bm)
     println()
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,7 +21,4 @@ makedocs(;
     pages = ["Home" => "index.md"],
 )
 
-deploydocs(;
-    repo = "github.com/Octogonapus/MutualInformationImageRegistration.jl",
-    devbranch = "main",
-)
+deploydocs(; repo = "github.com/Octogonapus/MutualInformationImageRegistration.jl", devbranch = "main")

--- a/src/MutualInformationImageRegistration.jl
+++ b/src/MutualInformationImageRegistration.jl
@@ -2,6 +2,7 @@ module MutualInformationImageRegistration
 
 using FastHistograms
 using OffsetArrays
+using LoopVectorization
 
 include("mutual_information.jl")
 include("register.jl")

--- a/src/MutualInformationImageRegistration.jl
+++ b/src/MutualInformationImageRegistration.jl
@@ -54,7 +54,7 @@ shift, mm, mms = register!(
     [300, 200, 330, 220] .+ padding .+ [expected_x, expected_y, expected_x, expected_y],
     MAX_SHIFT,
     MAX_SHIFT,
-    buffer
+    buffer,
 )
 
 # The shift we get out should be equal and opposite of the shift we applied

--- a/src/MutualInformationImageRegistration.jl
+++ b/src/MutualInformationImageRegistration.jl
@@ -4,6 +4,7 @@ using FastHistograms
 using OffsetArrays
 using LoopVectorization
 
+include("traits.jl")
 include("mutual_information.jl")
 include("register.jl")
 

--- a/src/mutual_information.jl
+++ b/src/mutual_information.jl
@@ -6,10 +6,7 @@ struct MutualInformationContainer{H,P<:MutualInformationParallelization}
     px_py::Array{Float32,2}
     nzs::BitArray{2}
 
-    function MutualInformationContainer(
-        hist::H,
-        p::P,
-    ) where {H,P<:MutualInformationParallelization}
+    function MutualInformationContainer(hist::H, p::P) where {H,P<:MutualInformationParallelization}
         pxy = counts(hist) ./ sum(counts(hist))
         px = sum(pxy, dims = 2)
         py = sum(pxy, dims = 1)
@@ -20,18 +17,16 @@ struct MutualInformationContainer{H,P<:MutualInformationParallelization}
     end
 end
 
-MutualInformationContainer(hist::H) where {H} =
-    MutualInformationContainer(hist, NoParallelization())
+MutualInformationContainer(hist::H) where {H} = MutualInformationContainer(hist, NoParallelization())
 
 MutualInformationParallelization(::MutualInformationContainer{H,P}) where {H,P} = P()
 
-"Compute the MI. The hist inside `mi` must already be incremeted."
+"""
+Compute the MI. The hist inside `mi` must already be incremeted.
+"""
 _mutual_information!(mi::MutualInformationContainer) = _mutual_information!(MutualInformationParallelization(mi), mi)
 
-function _mutual_information!(
-    p::MutualInformationParallelization,
-    mi::MutualInformationContainer,
-)
+function _mutual_information!(p::MutualInformationParallelization, mi::MutualInformationContainer)
     mi.pxy .= counts(mi.hist) ./ sum(counts(mi.hist))
     sum!(mi.px, mi.pxy)
     sum!(mi.py, mi.pxy)
@@ -98,11 +93,7 @@ function mutual_information!(
     get_buffer_crop,
     prefilter_frame_crop! = x -> nothing,
 )
-    mis = OffsetArray(
-        Array{Float32}(undef, length(range_x), length(range_y)),
-        range_x,
-        range_y,
-    )
+    mis = OffsetArray(Array{Float32}(undef, length(range_x), length(range_y)), range_x, range_y)
     fixed_vec = vec(fixed)
 
     # Crop and prefilter a section of `current_frame` big enough to handle the shift extents.
@@ -149,11 +140,7 @@ function mutual_information!(
     get_buffer_crop,
     kwargs...,
 )
-    mis = OffsetArray(
-        Array{Float32}(undef, length(range_x), length(range_y)),
-        range_x,
-        range_y,
-    )
+    mis = OffsetArray(Array{Float32}(undef, length(range_x), length(range_y)), range_x, range_y)
 
     prev_range_x = axes(prev_mis, 1)
     prev_range_y = axes(prev_mis, 2)

--- a/src/mutual_information.jl
+++ b/src/mutual_information.jl
@@ -26,8 +26,7 @@ MutualInformationContainer(hist::H) where {H} =
 MutualInformationParallelization(::MutualInformationContainer{H,P}) where {H,P} = P()
 
 "Compute the MI. The hist inside `mi` must already be incremeted."
-_mutual_information!(mi::MutualInformationContainer) =
-    (MutualInformationParallelization(mi), mi)
+_mutual_information!(mi::MutualInformationContainer) = _mutual_information!(MutualInformationParallelization(mi), mi)
 
 function _mutual_information!(
     p::MutualInformationParallelization,

--- a/src/mutual_information.jl
+++ b/src/mutual_information.jl
@@ -25,6 +25,7 @@ MutualInformationContainer(hist::H) where {H} =
 
 MutualInformationParallelization(::MutualInformationContainer{H,P}) where {H,P} = P()
 
+"Compute the MI. The hist inside `mi` must already be incremeted."
 _mutual_information!(mi::MutualInformationContainer) =
     (MutualInformationParallelization(mi), mi)
 

--- a/src/register.jl
+++ b/src/register.jl
@@ -189,7 +189,6 @@ end
 function set_buffer!(buffer, current_frame, moving_bbox, max_shift_x, max_shift_y)
     x_inds = (moving_bbox[1]-max_shift_x):(moving_bbox[3]+max_shift_x)
     y_inds = (moving_bbox[2]-max_shift_y):(moving_bbox[4]+max_shift_y)
-    @info "set_buffer!" size(buffer) size(view(current_frame, x_inds, y_inds))
     buffer .= view(current_frame, x_inds, y_inds)
     nothing
 end

--- a/src/register.jl
+++ b/src/register.jl
@@ -189,6 +189,7 @@ end
 function set_buffer!(buffer, current_frame, moving_bbox, max_shift_x, max_shift_y)
     x_inds = (moving_bbox[1]-max_shift_x):(moving_bbox[3]+max_shift_x)
     y_inds = (moving_bbox[2]-max_shift_y):(moving_bbox[4]+max_shift_y)
+    @info "set_buffer!" size(buffer) size(view(current_frame, x_inds, y_inds))
     buffer .= view(current_frame, x_inds, y_inds)
     nothing
 end

--- a/src/register.jl
+++ b/src/register.jl
@@ -159,14 +159,8 @@ function register!(
     prev_mis::Union{Missing,AbstractArray{Float32,2}};
     set_buffer! = (buffer, current_frame, moving_bbox) ->
         set_buffer!(buffer, current_frame, moving_bbox, maximum(range_x), maximum(range_y)),
-    get_buffer_crop = (buffer, moving_bbox, shift_x, shift_y) -> get_buffer_crop(
-        buffer,
-        moving_bbox,
-        shift_x,
-        shift_y,
-        maximum(range_x),
-        maximum(range_y),
-    ),
+    get_buffer_crop = (buffer, moving_bbox, shift_x, shift_y) ->
+        get_buffer_crop(buffer, moving_bbox, shift_x, shift_y, maximum(range_x), maximum(range_y)),
     prefilter_frame_crop! = x -> nothing,
 ) where {T<:Integer}
     mis = mutual_information!(
@@ -197,9 +191,7 @@ function get_buffer_crop(buffer, moving_bbox, shift_x, shift_y, max_shift_x, max
     # Extract the bbox + (shift_x, shift_y). We are extracting it from an array of
     # bbox ± max_shift so we need to transform the coordinates into the right frame by
     # subtracting the origin of the bbox ± max_shift frame.
-    x_inds =
-        ((moving_bbox[1]:moving_bbox[3]) .+ shift_x) .- (moving_bbox[1] - max_shift_x) .+ 1
-    y_inds =
-        ((moving_bbox[2]:moving_bbox[4]) .+ shift_y) .- (moving_bbox[2] - max_shift_y) .+ 1
+    x_inds = ((moving_bbox[1]:moving_bbox[3]) .+ shift_x) .- (moving_bbox[1] - max_shift_x) .+ 1
+    y_inds = ((moving_bbox[2]:moving_bbox[4]) .+ shift_y) .- (moving_bbox[2] - max_shift_y) .+ 1
     view(buffer, x_inds, y_inds)
 end

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -1,8 +1,14 @@
-"A trait for the ways the mutual information calculation can be parallelized."
+"""
+A trait for the ways the mutual information calculation can be parallelized.
+"""
 abstract type MutualInformationParallelization end
 
-"No threading nor vectorization."
+"""
+No threading nor vectorization.
+"""
 struct NoParallelization <: MutualInformationParallelization end
 
-"SIMD vectorization."
+"""
+SIMD vectorization.
+"""
 struct SIMD <: MutualInformationParallelization end

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -1,0 +1,8 @@
+"A trait for the ways the mutual information calculation can be parallelized."
+abstract type MutualInformationParallelization end
+
+"No threading nor vectorization."
+struct NoParallelization <: MutualInformationParallelization end
+
+"SIMD vectorization."
+struct SIMD <: MutualInformationParallelization end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ComputationalResources = "ed09eef8-17a6-5b46-8889-db040fac31e3"
 ImageFiltering = "6a3955dd-da59-5b1f-98d4-e7296123deb5"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,10 +5,8 @@ using JLD2, BenchmarkTools
 
 const MAX_SHIFT = 11
 const PADDING = [-10, -10, 10, 10]
-const ALL_PARALLELIZATIONS = [
-    MutualInformationImageRegistration.NoParallelization(),
-    MutualInformationImageRegistration.SIMD(),
-]
+const ALL_PARALLELIZATIONS =
+    [MutualInformationImageRegistration.NoParallelization(), MutualInformationImageRegistration.SIMD()]
 
 @testset "MutualInformationImageRegistration.jl" begin
     @testset "register without filtering ($p)" for p in ALL_PARALLELIZATIONS
@@ -36,8 +34,7 @@ const ALL_PARALLELIZATIONS = [
                 mi,
                 full_image,
                 fixed,
-                [300, 200, 330, 220] .+ PADDING .+
-                [expected_x, expected_y, expected_x, expected_y],
+                [300, 200, 330, 220] .+ PADDING .+ [expected_x, expected_y, expected_x, expected_y],
                 MAX_SHIFT,
                 MAX_SHIFT,
                 buffer,
@@ -66,12 +63,8 @@ const ALL_PARALLELIZATIONS = [
     @testset "register with filtering ($p)" for p in ALL_PARALLELIZATIONS
         function prefilter!(img::Array{UInt8,2})
             buf = Float32.(img)
-            buf = imfilter(
-                CPU1(Algorithm.FIR()),
-                buf,
-                (centered(ones(2, 1) ./ 2), centered(ones(1, 2) ./ 2)),
-                "reflect",
-            )
+            buf =
+                imfilter(CPU1(Algorithm.FIR()), buf, (centered(ones(2, 1) ./ 2), centered(ones(1, 2) ./ 2)), "reflect")
             img .= round.(UInt8, buf)
             return nothing
         end
@@ -102,8 +95,7 @@ const ALL_PARALLELIZATIONS = [
                 mi,
                 full_image,
                 fixed,
-                [300, 200, 330, 220] .+ PADDING .+
-                [expected_x, expected_y, expected_x, expected_y],
+                [300, 200, 330, 220] .+ PADDING .+ [expected_x, expected_y, expected_x, expected_y],
                 MAX_SHIFT,
                 MAX_SHIFT,
                 buffer;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,10 @@
 using MutualInformationImageRegistration
 using Random, ImageFiltering, ComputationalResources, Test
 using MutualInformationImageRegistration.FastHistograms
-using JLD2
+using JLD2, BenchmarkTools
 
-MAX_SHIFT = 11
-padding = [-10, -10, 10, 10]
+const MAX_SHIFT = 11
+const padding = [-10, -10, 10, 10]
 
 @testset "MutualInformationImageRegistration.jl" begin
     @testset "register without filtering" begin
@@ -100,5 +100,21 @@ padding = [-10, -10, 10, 10]
                 break
             end
         end
+    end
+
+    @testset "computing mutual_information doesn't allocate" begin
+        mi = MutualInformationContainer(
+            create_fast_histogram(
+                FastHistograms.FixedWidth(),
+                FastHistograms.Arithmetic(),
+                FastHistograms.NoParallelization(),
+                [(0x00, 0xff, 8), (0x00, 0xff, 8)],
+            ),
+        )
+
+        x = rand(UInt8, 500, 300)
+        y = rand(UInt8, 500, 300)
+
+        @test 0 == @ballocated mutual_information!($mi, $x, $y)
     end
 end


### PR DESCRIPTION
### Description of the Change

This PR adds test that ensure that computing mutual information doesn't allocate (and also fixes some allocations).
This PR also adds a new trait, `MutualInformationParallelization`, to model SIMD separately from the default.

### Motivation

This code allocated before, which was the cause of some performance problems.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

The new unit tests verify that there are no allocations in that code.

### Applicable Issues

<!-- Enter any applicable Issues here. E.g., "Closes #49." -->
